### PR TITLE
fixes duplicate pointers 'The Pro State of Mind' in /lifeprocedure : life@procedure page

### DIFF
--- a/src/app/lifeprocedure/page.tsx
+++ b/src/app/lifeprocedure/page.tsx
@@ -156,38 +156,12 @@ const LifeProcedure = () => {
           </div>
         ))}
       </section>
-      <Pointers
-        title="The Pro State of Mind"
-        pointers={pointerData}
-        eachElementClassName="text-[0.625rem] w-full md:w-[28%] lg:w-[28%] mr-0 md:mr-[5.3%] mb-12 md:mb-[5%]"
-      />
       <section className="mb-28">
-        <div className="container-padding">
-          <h2 className="mb-12">The Pro State of Mind</h2>
-          <div className="flex flex-wrap -mb-[5%]">
-            {pointerData.map((data, index) => (
-              <div
-                key={data.heading}
-                className="w-full md:w-[28%] md:mr-[5.3%] mb-12 md:mb-[5%]"
-              >
-                <h3
-                  className={twMerge(
-                    'text-gray-400 dot text-7xl font-bold mb-2.5',
-                    data.color
-                  )}
-                >
-                  {index + 1}
-                </h3>
-                <h4 className="text-3xl mb-2.5 text-gray-600 font-bold">
-                  {data.heading}
-                </h4>
-                <p className="text-[#212529] text-[0.625rem]">
-                  {data.description}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
+        <Pointers
+          title="The Pro State of Mind"
+          pointers={pointerData}
+          eachElementClassName="text-[0.625rem] w-full md:w-[28%] lg:w-[28%] mr-0 md:mr-[5.3%] mb-12 md:mb-[5%]"
+        />
       </section>
       <section className="mb-28">
         <PhotoSlider photoData={photoData} />


### PR DESCRIPTION
## Description

Fixed the issue of duplicate pointers to 'The Pro State of Mind' in the `/lifeprocedure` page within the `life@procedure` section. The redundant pointers were removed, ensuring a single reference for improved clarity and user experience.

---

## Type of Change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  
- [ ] Code refactoring  
- [ ] Other (please describe):  

---

## Testing

- [x] Manual testing performed: Verified the `/lifeprocedure` page to confirm that only one pointer to 'The Pro State of Mind' is present.  
- [ ] Unit tests added/updated  
- [ ] Integration tests added/updated  

---

## Screenshots/Videos

![solved](https://github.com/user-attachments/assets/811f6edf-9ab8-434f-9b09-387f12d7c498)

---

## Related Issues

Closes #11 

---

## Checklist

- [x] Code follows project style guidelines  
- [ ] Comments added for complex logic  
- [ ] Documentation updated  
- [ ] All tests passing  
- [x] No new warnings generated  
- [x] Self-review performed  

---

## Additional Notes

No additional notes. Let me know if further changes are needed.
